### PR TITLE
Release Boring YURI v1.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Boring YURI 1.2.0 (2022-01-06)
+* Add support of inheritance in independent `Uri` data classes ([Issue #20](https://github.com/anton-novikau/boringYURI/issues/20)).
+* Remove support of ordered path segments in favor of named path segments ([Issue #22](https://github.com/anton-novikau/boringYURI/issues/22)).
+* Add `@Override` annotations to the generated getter methods in independent `Uri` data classes.
+* Upgrade the dependencies.
+
 ## Boring YURI 1.1.4 (2021-10-24)
 
 * Fix duplicates handling in `Uri` path segments ([Bug #21](https://github.com/anton-novikau/boringYURI/issues/21)).

--- a/README.md
+++ b/README.md
@@ -1045,7 +1045,7 @@ To add `Boring Yuri` to your project, include the following in your app module `
 ```groovy
 android {
   ...
-  // Boring YURI requires Java 8.
+  // Boring YURI requires at least Java 8 compatibility.
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_1_8
     targetCompatibility JavaVersion.VERSION_1_8
@@ -1057,8 +1057,8 @@ With Java only:
 
 ```groovy
 dependencies {
-  implementation "com.github.anton-novikau:boringyuri-api:1.1.4"
-  annotationProcessor "com.github.anton-novikau:boringyuri-processor:1.1.4"
+  implementation "com.github.anton-novikau:boringyuri-api:1.2.0"
+  annotationProcessor "com.github.anton-novikau:boringyuri-processor:1.2.0"
 }
 ```
 
@@ -1068,8 +1068,8 @@ With Kotlin:
 apply plugin: 'kotlin-kapt'
 
 dependencies {
-  implementation "com.github.anton-novikau:boringyuri-api:1.1.4"
-  kapt "com.github.anton-novikau:boringyuri-processor:1.1.4"
+  implementation "com.github.anton-novikau:boringyuri-api:1.2.0"
+  kapt "com.github.anton-novikau:boringyuri-processor:1.2.0"
 }
 ```
 Snapshots of the development version are available in [Sonatype's snapshots repository][4].

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ in common with them.
   * [Constant query parameters](#constant-query-parameters)
   * [Deserialize data from Uri](#deserialize-data-from-uri)
     * [Independent Uri data class](#independent-uri-data-class)
+      * [Inheritance in Uri data](#inheritance-in-uri-data)
   * [Default values](#default-values)
   * [Matching URIs in Android ContentProvider](#matching-uris-in-android-contentprovider)
     * [Disable URI matching based on a build type or a flavor](#disable-uri-matching-based-on-a-build-type-or-a-flavor)
@@ -164,30 +165,6 @@ query parameters or path segments. It is still highly recommended to specify the
 in `@Path` and `@Param` annotations in order to make sure somebody won't refactor the code and
 break the contract with the receiver's side accidentally (eg. back-end may still expect the old
 query parameter names).
-
-Path segment name is not obligatory, but in this case the path method parameters will appear
-in the `Uri` in the exactly same order as they defined in the method signature, i.e. for
-the builder method:
-
-```java
-    @UriBuilder("/user")
-    Uri buildUserUri(@Path String group, @Path int userId);
-```
-
-Calling `builder.buildUserUri("students", 42)` will give you
-`https://example.com/user/students/42`.
- 
-But calling the builder with the parameters switched:
-
-```java
-    @UriBuilder("/user")
-    Uri buildUserUri(@Path int userId, @Path String group);
-```
-
-Will give you `https://example.com/user/42/students`.
-
-**NOTE:** relying on the method parameters order is highly not recommended as it gives less
-flexibility and there is a bigger chance to make a mistake. Use the named path segments instead.
 
 **IMPORTANT:** `@Path` method parameters **can not be nullable**. They must be explicitly
 annotated with `@NonNull` in Java or must have a non-nullable type in Kotlin. The only exception
@@ -629,15 +606,94 @@ public interface UserData {
 Here the path segment `id` can be parsed from `content://com.example.provider/42` using
 the `UriData` class, but can not be parsed from `content://com.example.provider/user/42`.
 
-**NOTE:** when the base path is not defined in `@UriData`, the order of the getter methods will
-be used to parse the specific segments. Relying on the method order is **highly not recommended**
-as it may give an unpredictable result and it's easier to make a mistake. So named path segments
-are always more preferable.
-
 **IMPORTANT:** the cost of the "independence" is that you have to manage manually the type
 consistency of the builder method parameters and the getters of the data class (if you have the
 builders of course). `@WithUriData` does it for you since there is one source of truth: the builder
 method in the factory interface.
+
+##### Inheritance in Uri data
+When two independent `Uri` data classes may have common properties, it is possible to use interface
+inheritance in order to avoid defining same query parameters and path segments in multiple files.
+Besides inheritance can also be used to generate data classes not only for descendants, but also
+for ancestors, so it could be possible to parse the data partially without knowing a concrete
+type of the `Uri` data.
+
+For example we could to have `Uri`s for Images, Video and Sounds. All three types may have `id`,
+`mediaType` and `fileSize`. Some of the properties may be common only for the two types out of three,
+eg. Images and Video may have a `thumbnail` and Sound and Video may have a `duration`. And finally
+some of the properties could exist only for the specific types, eg. Sound may have `genre` and Image
+may have a `description`.
+
+So we may create a base `Uri` data interface `FileData`:
+```java
+@UriData("/*/{id}")
+public interface FileData {
+    @Path
+    long getId();
+
+    @Param
+    String getMediaType();
+
+    @Param
+    long getFileSize();
+}
+```
+Then we create a base interface for Image and Video which is called `MediaData`:
+```java
+@UriData
+public interface MediaData {
+    @Param
+    Uri getThumbnail();
+}
+```
+
+And a base interface for Video and Sound which is called `PlayableData`:
+```java
+@UriData
+public interface PlayableData {
+    @Param
+    long getDuration();
+}
+```
+
+Now we may define the concrete interfaces for Image, Video and Sound:
+```java
+@UriData("/image/{id}")
+public interface ImageData extends MediaData, FileData {
+    @Param("desc")
+    int getDescription();
+}
+
+@UriData("/video/{id}")
+public interface VideoData extends MediaData, PlayableData, FileData {
+
+}
+
+@UriData("/sound/{id}")
+public interface SoundData extends PlayableData, FileData {
+  @Param
+  String getGenre();
+}
+```
+
+Now if we have three `Uri`s for each of the file types:
+```
+1. content://com.example.provider/image/42?mediaType=image%2Fjpeg&fileSize=100&desc=Some%2BDescription&thumbnail=path_to_thumb
+2. content://com.example.provider/video/24?mediaType=video%2Fmp4&fileSize=400&duration=300&thumbnail=path_to_video_thumb
+3. content://com.example.provider/sound/22?mediaType=audio%2Fogg&fileSize=150&duration=400&genre=rock
+```
+
+To obtain all properties for the `Uri` `#1` a generated `ImageDataImpl` can be used. For `#2` and `#3`
+it's `VideoDataImpl` and `SoundDataImpl` respectively. But if we know there is one of these three
+`Uri`s and we don't care about the type specific properties, but we only need to obtain a
+`mimeType` and `id`, we may use `FileDataImpl` and it will work just fine.
+
+**NOTE:** generated classes `SoundDataImpl` and `VideoDataImpl` do not inherit neither
+`PlayableDataImpl` nor `FileDataImpl`, but only the interfaces.
+
+If a parent interface doesn't need to have a generated data class, because it's only used to specify
+common query parameters and path segments, then just omit the `@UriData` and all the property
+getters will be generated in the specific implementation anyway.
 
 ### Default values
 
@@ -1047,14 +1103,6 @@ dependencies {
   Enabling this option allows to use the memory more efficiently and to create every instance of
   the specific type adapter only once. When the option is turned off, every instance of the adapter
   is created at use which gives to garbage collector more work.
- * `boringyuri.suppress_warning.ordered_segments` –  :bangbang: **DEPRECATED**. Support of ordered
-  path segments [will be removed](https://github.com/anton-novikau/boringYURI/issues/22) in `1.2.0`.
-  ~~every time you use ordered path segments
-  instead of named path segments, you'll see the a compilation warning message `Template
-  {path name} is not found in @UriBuilder("/base/path"). Fallback to ordered segments may
-  cause an unpredictable result`. This message here is to warn that the ordered path approach
-  is not recommended and you'd better switch to the named path segments. But if you're aware of
-  what you're doing, you may turn the message off setting the option to `true`.~~
 
 To enable any of the options above you need to include the following in your app module
 `build.gradle` file:

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -23,5 +23,5 @@ dependencies {
     api "androidx.annotation:annotation:$annotationVersion"
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
+sourceCompatibility = JavaVersion.VERSION_11
+targetCompatibility = JavaVersion.VERSION_11

--- a/api/src/main/java/boringyuri/api/UriBuilder.java
+++ b/api/src/main/java/boringyuri/api/UriBuilder.java
@@ -47,7 +47,7 @@ public @interface UriBuilder {
      * <p>
      * Relative {@code Uri} path. Can contain the placeholders for <code>&#64;Path</code>
      * method parameters that are used as variable segments of the {@code Uri} path.
-     *</p>
+     * </p>
      * <p>If the path doesn't start with a '/', the builder will prepend the
      * given path with a '/'.</p>
      */

--- a/api/src/main/java/boringyuri/api/UriData.java
+++ b/api/src/main/java/boringyuri/api/UriData.java
@@ -102,7 +102,7 @@ public @interface UriData {
      * <p>
      * Relative {@code Uri} path that can be used as a reference to parse
      * <code>&#64;Path</code> segments into an appropriate getter method.
-     *</p>
+     * </p>
      * <p>
      * If the same data class is used for two or more different {@code Uri}s,
      * the wildcard <code>&#42;</code> can be used to replace the constant path

--- a/api/src/main/java/boringyuri/api/adapter/TypeAdapter.java
+++ b/api/src/main/java/boringyuri/api/adapter/TypeAdapter.java
@@ -64,7 +64,7 @@ import java.lang.annotation.Target;
  *
  *      }
  * </code></pre>
- *
+ * <p>
  * For parameters of an {@code array} type the <code>&#64;TypeAdapter</code> should be used
  * for an {@code array} element, not for the {@code array} itself. Example:
  *

--- a/build.gradle
+++ b/build.gradle
@@ -16,20 +16,20 @@
 
 buildscript {
     // android
-    ext.gradlePluginVersion = '4.2.0'
-    ext.buildToolsVersion = '30.0.3'
+    ext.gradlePluginVersion = '7.0.4'
+    ext.buildToolsVersion = '31.0.0'
     ext.compile_sdk_version = 31
     ext.min_sdk_version = 17
     ext.target_sdk_version = 31
 
     // androidx
-    ext.constraintLayoutVersion = '2.1.1'
-    ext.appCompatVersion = '1.3.1'
+    ext.constraintLayoutVersion = '2.1.2'
+    ext.appCompatVersion = '1.4.0'
     ext.annotationVersion = '1.1.0'
-    ext.lifecycleVersion = '2.3.1'
+    ext.lifecycleVersion = '2.4.0'
 
     // kotlin
-    ext.kotlinVersion = '1.5.31'
+    ext.kotlinVersion = '1.6.10'
     ext.dokkaVersion = '1.5.31'
 
     // dagger

--- a/dagger-sample/build.gradle
+++ b/dagger-sample/build.gradle
@@ -38,8 +38,8 @@ android {
     }
 
     compileOptions {
-        targetCompatibility 1.8
-        sourceCompatibility 1.8
+        targetCompatibility JavaVersion.VERSION_11
+        sourceCompatibility JavaVersion.VERSION_11
     }
 }
 
@@ -78,6 +78,6 @@ kapt {
 
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
     kotlinOptions {
-        jvmTarget = "1.8" // in order to compile Kotlin to java 8 bytecode
+        jvmTarget = "11" // in order to compile Kotlin to java 11 bytecode
     }
 }

--- a/dagger-sample/build.gradle
+++ b/dagger-sample/build.gradle
@@ -79,5 +79,6 @@ kapt {
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
     kotlinOptions {
         jvmTarget = "11" // in order to compile Kotlin to java 11 bytecode
+        freeCompilerArgs = ['-Xjvm-default=all']
     }
 }

--- a/dagger-sample/src/main/java/boringyuri/dagger/sample/di/AppComponent.kt
+++ b/dagger-sample/src/main/java/boringyuri/dagger/sample/di/AppComponent.kt
@@ -22,11 +22,13 @@ import dagger.android.support.AndroidSupportInjectionModule
 import javax.inject.Singleton
 
 @Singleton
-@Component(modules = [
-    AndroidSupportInjectionModule::class,
-    AppModule::class,
-    BoringYuriModule::class
-])
+@Component(
+    modules = [
+        AndroidSupportInjectionModule::class,
+        AppModule::class,
+        BoringYuriModule::class
+    ]
+)
 interface AppComponent : AndroidInjector<App> {
     @Component.Factory
     abstract class Factory : AndroidInjector.Factory<App>

--- a/dagger-sample/src/main/java/boringyuri/dagger/sample/uri/LocationUriBuilder.kt
+++ b/dagger-sample/src/main/java/boringyuri/dagger/sample/uri/LocationUriBuilder.kt
@@ -46,5 +46,6 @@ interface LocationUriBuilder {
     @BooleanParam(name = "sensor", value = true)
     fun buildGeocodeUri(
         @Param @TypeAdapter(CoordinatesTypeAdapter::class) latlng: Pair<Long, Long>,
-        @Param address: Address): Uri
+        @Param address: Address
+    ): Uri
 }

--- a/dagger-sample/src/main/java/boringyuri/dagger/sample/uri/UserProviderUriBuilder.java
+++ b/dagger-sample/src/main/java/boringyuri/dagger/sample/uri/UserProviderUriBuilder.java
@@ -28,7 +28,7 @@ import boringyuri.api.adapter.TypeAdapter;
 import boringyuri.dagger.sample.data.User;
 import boringyuri.dagger.sample.data.adapter.AdminTypeAdapter;
 
-@UriFactory(scheme = "https", authority="example.com")
+@UriFactory(scheme = "https", authority = "example.com")
 public interface UserProviderUriBuilder {
 
     @NonNull

--- a/dagger/README.md
+++ b/dagger/README.md
@@ -58,7 +58,7 @@ With Java only:
 ```groovy
 dependencies {
          ...
-  annotationProcessor "com.github.anton-novikau:boringyuri-dagger:1.1.4"
+  annotationProcessor "com.github.anton-novikau:boringyuri-dagger:1.2.0"
 }
 ```
 
@@ -67,7 +67,7 @@ With Kotlin:
 ```groovy
 dependencies {
         ...
-  kapt "com.github.anton-novikau:boringyuri-dagger:1.1.4"
+  kapt "com.github.anton-novikau:boringyuri-dagger:1.2.0"
 }
 ```
 

--- a/dagger/build.gradle
+++ b/dagger/build.gradle
@@ -37,5 +37,11 @@ dependencies {
     kapt "net.ltgt.gradle.incap:incap-processor:$incapVersion"
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
+sourceCompatibility = JavaVersion.VERSION_11
+targetCompatibility = JavaVersion.VERSION_11
+
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
+    kotlinOptions {
+        jvmTarget = "11" // in order to compile Kotlin to java 11 bytecode
+    }
+}

--- a/dagger/src/main/java/boringyuri/dagger/DaggerModuleProcessor.kt
+++ b/dagger/src/main/java/boringyuri/dagger/DaggerModuleProcessor.kt
@@ -31,7 +31,7 @@ import javax.lang.model.SourceVersion
 
 @Suppress("unused") // class is used by @AutoService
 @AutoService(Processor::class)
-@SupportedSourceVersion(SourceVersion.RELEASE_8)
+@SupportedSourceVersion(SourceVersion.RELEASE_11)
 @IncrementalAnnotationProcessor(IncrementalAnnotationProcessorType.AGGREGATING)
 @SupportedOptions(ProcessorOptions.OPT_DAGGER_BORING_MODULE)
 class DaggerModuleProcessor : BoringAnnotationProcessor() {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Publishing
 USER = novikau
 GROUP = com.github.anton-novikau
-VERSION_NAME = 1.1.4
+VERSION_NAME = 1.2.0
 
 POM_DESCRIPTION = An annotation processor library for Uri building and parsing routines.
 POM_LICENCE_NAME = The Apache Software License, Version 2.0

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-all.zip

--- a/processor/build.gradle
+++ b/processor/build.gradle
@@ -37,5 +37,11 @@ dependencies {
     kapt "net.ltgt.gradle.incap:incap-processor:$incapVersion"
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
+sourceCompatibility = JavaVersion.VERSION_11
+targetCompatibility = JavaVersion.VERSION_11
+
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
+    kotlinOptions {
+        jvmTarget = "11" // in order to compile Kotlin to java 11 bytecode
+    }
+}

--- a/processor/src/main/java/boringyuri/processor/IndependentUriDataProcessor.kt
+++ b/processor/src/main/java/boringyuri/processor/IndependentUriDataProcessor.kt
@@ -23,6 +23,7 @@ import boringyuri.api.adapter.TypeAdapter
 import boringyuri.processor.base.BoringAnnotationProcessor
 import boringyuri.processor.base.BoringProcessingStep
 import boringyuri.processor.base.ProcessingSession
+import boringyuri.processor.type.CommonTypeName
 import boringyuri.processor.util.AnnotationHandler
 import boringyuri.processor.util.ProcessorOptions
 import com.google.auto.service.AutoService
@@ -55,6 +56,7 @@ class IndependentUriDataProcessor : BoringAnnotationProcessor() {
 
     companion object {
         private val INTERNAL_ANNOTATIONS: Set<TypeName> = hashSetOf(
+            CommonTypeName.OVERRIDE,
             ClassName.get(UriData::class.java),
             ClassName.get(Path::class.java),
             ClassName.get(Param::class.java),

--- a/processor/src/main/java/boringyuri/processor/IndependentUriDataProcessor.kt
+++ b/processor/src/main/java/boringyuri/processor/IndependentUriDataProcessor.kt
@@ -38,7 +38,7 @@ import javax.lang.model.SourceVersion
 
 @Suppress("unused") // class is used by @AutoService
 @AutoService(Processor::class)
-@SupportedSourceVersion(SourceVersion.RELEASE_8)
+@SupportedSourceVersion(SourceVersion.RELEASE_11)
 @IncrementalAnnotationProcessor(IncrementalAnnotationProcessorType.ISOLATING)
 @SupportedOptions(
     ProcessorOptions.OPT_TYPE_ADAPTER_FACTORY

--- a/processor/src/main/java/boringyuri/processor/TypeAdapterFactoryGeneratorStep.kt
+++ b/processor/src/main/java/boringyuri/processor/TypeAdapterFactoryGeneratorStep.kt
@@ -20,12 +20,21 @@ import boringyuri.api.adapter.TypeAdapter
 import boringyuri.processor.base.BoringProcessingStep
 import boringyuri.processor.base.ProcessingSession
 import boringyuri.processor.ext.valueMirror
-import boringyuri.processor.type.CommonTypeName.*
+import boringyuri.processor.type.CommonTypeName.ANY_TYPE_ADAPTER
+import boringyuri.processor.type.CommonTypeName.CLASS
+import boringyuri.processor.type.CommonTypeName.HASH_MAP
+import boringyuri.processor.type.CommonTypeName.MAP
+import boringyuri.processor.type.CommonTypeName.NON_NULL
 import boringyuri.processor.util.ProcessorOptions.getTypeAdapterFactory
 import com.google.auto.common.MoreTypes
 import com.google.common.collect.ImmutableSet
 import com.google.common.collect.ImmutableSetMultimap
-import com.squareup.javapoet.*
+import com.squareup.javapoet.ClassName
+import com.squareup.javapoet.FieldSpec
+import com.squareup.javapoet.MethodSpec
+import com.squareup.javapoet.ParameterizedTypeName
+import com.squareup.javapoet.TypeSpec
+import com.squareup.javapoet.WildcardTypeName
 import javax.lang.model.element.Element
 import javax.lang.model.element.Modifier
 
@@ -138,5 +147,4 @@ class TypeAdapterFactoryGeneratorStep(
 
         return method.build()
     }
-
 }

--- a/processor/src/main/java/boringyuri/processor/TypeAdapterProcessor.kt
+++ b/processor/src/main/java/boringyuri/processor/TypeAdapterProcessor.kt
@@ -31,7 +31,7 @@ import javax.lang.model.SourceVersion
 
 @Suppress("unused") // class is used by @AutoService
 @AutoService(Processor::class)
-@SupportedSourceVersion(SourceVersion.RELEASE_8)
+@SupportedSourceVersion(SourceVersion.RELEASE_11)
 @IncrementalAnnotationProcessor(IncrementalAnnotationProcessorType.AGGREGATING)
 @SupportedOptions(ProcessorOptions.OPT_TYPE_ADAPTER_FACTORY)
 class TypeAdapterProcessor : BoringAnnotationProcessor() {

--- a/processor/src/main/java/boringyuri/processor/UriDataGeneratorStep.kt
+++ b/processor/src/main/java/boringyuri/processor/UriDataGeneratorStep.kt
@@ -17,14 +17,23 @@ package boringyuri.processor
 
 import boringyuri.processor.base.BoringProcessingStep
 import boringyuri.processor.base.ProcessingSession
+import boringyuri.processor.type.CommonTypeName.ANDROID_URI
+import boringyuri.processor.type.CommonTypeName.NON_NULL
+import boringyuri.processor.type.CommonTypeName.OVERRIDE
+import boringyuri.processor.type.CommonTypeName.STRING
+import boringyuri.processor.type.TypeConverter
 import boringyuri.processor.uripart.ReadPathSegment
 import boringyuri.processor.uripart.ReadQueryParameter
 import boringyuri.processor.uripart.TemplatePathSegment
 import boringyuri.processor.util.AnnotationHandler
-import boringyuri.processor.type.CommonTypeName.*
 import boringyuri.processor.util.ProcessorOptions.getTypeAdapterFactory
-import boringyuri.processor.type.TypeConverter
-import com.squareup.javapoet.*
+import com.squareup.javapoet.ClassName
+import com.squareup.javapoet.CodeBlock
+import com.squareup.javapoet.FieldSpec
+import com.squareup.javapoet.MethodSpec
+import com.squareup.javapoet.ParameterSpec
+import com.squareup.javapoet.TypeName
+import com.squareup.javapoet.TypeSpec
 import javax.lang.model.element.Element
 import javax.lang.model.element.Modifier
 
@@ -227,5 +236,4 @@ abstract class UriDataGeneratorStep protected constructor(
 
         private val PATH_TEMPLATE_REGEX = "^\\{([a-zA-Z0-9_-]+)}$".toRegex()
     }
-
 }

--- a/processor/src/main/java/boringyuri/processor/UriDataGeneratorStep.kt
+++ b/processor/src/main/java/boringyuri/processor/UriDataGeneratorStep.kt
@@ -106,13 +106,21 @@ abstract class UriDataGeneratorStep protected constructor(
 
         var uriPartIndex = 0
         uriMetadata.pathSegments.forEach {
-            val method = generateGetterMethodImpl(PathSegmentUriPart(it), 1 shl uriPartIndex)
+            val method = generateGetterMethodImpl(
+                uriPart = PathSegmentUriPart(it),
+                parseFlagValue = 1 shl uriPartIndex,
+                overrides = superInterface != null
+            )
             classContent.addMethod(method)
             uriPartIndex++
         }
 
         uriMetadata.queryParameters.forEach {
-            val method = generateGetterMethodImpl(QueryParameterUriPart(it), 1 shl uriPartIndex)
+            val method = generateGetterMethodImpl(
+                uriPart = QueryParameterUriPart(it),
+                parseFlagValue = 1 shl uriPartIndex,
+                overrides = superInterface != null
+            )
             classContent.addMethod(method)
             uriPartIndex++
         }
@@ -154,10 +162,14 @@ abstract class UriDataGeneratorStep protected constructor(
 
     private fun generateGetterMethodImpl(
         uriPart: UriPart,
-        parseFlagValue: Int
+        parseFlagValue: Int,
+        overrides: Boolean
     ): MethodSpec {
         val field = uriPart.fieldSpec
         val method = uriPart.createMethodSignature(annotationHandler)
+        if (overrides) {
+            method.addAnnotation(OVERRIDE)
+        }
 
         method.beginControlFlow("if ((\$N & \$L) != 0)", parseFlagField, parseFlagValue)
         method.addStatement("return \$N", field)

--- a/processor/src/main/java/boringyuri/processor/UriFactoryProcessor.kt
+++ b/processor/src/main/java/boringyuri/processor/UriFactoryProcessor.kt
@@ -39,7 +39,7 @@ import javax.lang.model.SourceVersion
 
 @Suppress("unused") // class is used by @AutoService
 @AutoService(Processor::class)
-@SupportedSourceVersion(SourceVersion.RELEASE_8)
+@SupportedSourceVersion(SourceVersion.RELEASE_11)
 @IncrementalAnnotationProcessor(IncrementalAnnotationProcessorType.ISOLATING)
 @SupportedOptions(
     ProcessorOptions.OPT_TYPE_ADAPTER_FACTORY

--- a/processor/src/main/java/boringyuri/processor/UriFactoryProcessor.kt
+++ b/processor/src/main/java/boringyuri/processor/UriFactoryProcessor.kt
@@ -15,9 +15,21 @@
  */
 package boringyuri.processor
 
-import boringyuri.api.*
+import boringyuri.api.DefaultValue
+import boringyuri.api.Param
+import boringyuri.api.Path
+import boringyuri.api.UriBuilder
+import boringyuri.api.UriFactory
+import boringyuri.api.WithUriData
 import boringyuri.api.adapter.TypeAdapter
-import boringyuri.api.constant.*
+import boringyuri.api.constant.BooleanParam
+import boringyuri.api.constant.BooleanParams
+import boringyuri.api.constant.DoubleParam
+import boringyuri.api.constant.DoubleParams
+import boringyuri.api.constant.LongParam
+import boringyuri.api.constant.LongParams
+import boringyuri.api.constant.StringParam
+import boringyuri.api.constant.StringParams
 import boringyuri.api.matcher.MatcherCode
 import boringyuri.api.matcher.MatchesTo
 import boringyuri.api.matcher.WithUriMatcher

--- a/processor/src/main/java/boringyuri/processor/UriMatcherGeneratorStep.kt
+++ b/processor/src/main/java/boringyuri/processor/UriMatcherGeneratorStep.kt
@@ -16,7 +16,9 @@
 
 package boringyuri.processor
 
-import boringyuri.api.*
+import boringyuri.api.Path
+import boringyuri.api.UriBuilder
+import boringyuri.api.UriFactory
 import boringyuri.api.matcher.MatcherCode
 import boringyuri.api.matcher.MatchesTo
 import boringyuri.api.matcher.WithUriMatcher
@@ -25,11 +27,20 @@ import boringyuri.processor.base.BoringProcessingStep
 import boringyuri.processor.base.ProcessingSession
 import boringyuri.processor.ext.getAnnotation
 import boringyuri.processor.ext.requireAnnotation
-import boringyuri.processor.type.CommonTypeName.*
+import boringyuri.processor.type.CommonTypeName.ANDROID_URI
+import boringyuri.processor.type.CommonTypeName.ANDROID_URI_MATCHER
+import boringyuri.processor.type.CommonTypeName.NON_NULL
+import boringyuri.processor.type.CommonTypeName.OVERRIDE
+import boringyuri.processor.type.CommonTypeName.STRING
+import boringyuri.processor.type.CommonTypeName.UNSUPPORTED_OPERATION
 import com.google.common.collect.ImmutableSet
 import com.google.common.collect.ImmutableSetMultimap
-import com.squareup.javapoet.*
-import java.util.*
+import com.squareup.javapoet.ClassName
+import com.squareup.javapoet.FieldSpec
+import com.squareup.javapoet.MethodSpec
+import com.squareup.javapoet.ParameterSpec
+import com.squareup.javapoet.TypeName
+import com.squareup.javapoet.TypeSpec
 import javax.lang.model.element.Element
 import javax.lang.model.element.ExecutableElement
 import javax.lang.model.element.Modifier
@@ -248,7 +259,7 @@ class UriMatcherGeneratorStep(
     ): String? {
         return matchesToAnnotation.value.takeIf {
             it.matches(FIELD_NAME_REGEX)
-        }?.toUpperCase(Locale.ENGLISH)
+        }?.uppercase()
     }
 
     private fun generateUriMatcherContent(
@@ -415,7 +426,7 @@ class UriMatcherGeneratorStep(
         method.endControlFlow()
         method.addStatement("return \$T.toString(\$N)", TypeName.INT.box(), codeParam)
 
-        return method.build();
+        return method.build()
     }
 
     private fun createMatcherCode(

--- a/processor/src/main/java/boringyuri/processor/base/AbortProcessingException.kt
+++ b/processor/src/main/java/boringyuri/processor/base/AbortProcessingException.kt
@@ -17,7 +17,6 @@
 package boringyuri.processor.base
 
 import boringyuri.processor.util.Logger
-import java.lang.RuntimeException
 import javax.lang.model.element.Element
 
 class AbortProcessingException(message: String) : RuntimeException(message) {
@@ -27,5 +26,4 @@ class AbortProcessingException(message: String) : RuntimeException(message) {
                 message: String,
                 vararg args: Any?
     ) : this(logger.error(originatingElement, message, *args))
-
 }

--- a/processor/src/main/java/boringyuri/processor/ext/Elements.kt
+++ b/processor/src/main/java/boringyuri/processor/ext/Elements.kt
@@ -19,7 +19,11 @@ package boringyuri.processor.ext
 import boringyuri.api.adapter.TypeAdapter
 import boringyuri.processor.util.AnnotationHandler
 import boringyuri.processor.util.buildGetterName
-import com.squareup.javapoet.*
+import com.squareup.javapoet.ClassName
+import com.squareup.javapoet.FieldSpec
+import com.squareup.javapoet.MethodSpec
+import com.squareup.javapoet.ParameterSpec
+import com.squareup.javapoet.TypeName
 import org.apache.commons.lang3.StringUtils
 import javax.lang.model.element.Element
 import javax.lang.model.element.ExecutableElement

--- a/processor/src/main/java/boringyuri/processor/type/ConversionStrategy.kt
+++ b/processor/src/main/java/boringyuri/processor/type/ConversionStrategy.kt
@@ -16,7 +16,11 @@
 package boringyuri.processor.type
 
 import boringyuri.processor.util.Counter
-import com.squareup.javapoet.*
+import com.squareup.javapoet.CodeBlock
+import com.squareup.javapoet.FieldSpec
+import com.squareup.javapoet.ParameterSpec
+import com.squareup.javapoet.ParameterizedTypeName
+import com.squareup.javapoet.TypeName
 import javax.lang.model.element.Element
 import javax.lang.model.type.ArrayType
 import javax.lang.model.type.DeclaredType

--- a/processor/src/main/java/boringyuri/processor/type/TypeConverter.kt
+++ b/processor/src/main/java/boringyuri/processor/type/TypeConverter.kt
@@ -17,10 +17,15 @@
 package boringyuri.processor.type
 
 import boringyuri.processor.base.AbortProcessingException
-import boringyuri.processor.type.CommonTypeName.*
+import boringyuri.processor.type.CommonTypeName.ANDROID_URI
+import boringyuri.processor.type.CommonTypeName.STRING
 import boringyuri.processor.util.Logger
 import com.google.auto.common.MoreTypes
-import com.squareup.javapoet.*
+import com.squareup.javapoet.ClassName
+import com.squareup.javapoet.CodeBlock
+import com.squareup.javapoet.FieldSpec
+import com.squareup.javapoet.ParameterSpec
+import com.squareup.javapoet.TypeName
 import javax.lang.model.element.Element
 import javax.lang.model.type.TypeMirror
 

--- a/processor/src/main/java/boringyuri/processor/uripart/PathSegment.kt
+++ b/processor/src/main/java/boringyuri/processor/uripart/PathSegment.kt
@@ -20,11 +20,16 @@ import boringyuri.processor.base.AbortProcessingException
 import boringyuri.processor.ext.createMethodSignature
 import boringyuri.processor.ext.findTypeAdapter
 import boringyuri.processor.ext.valueMirror
-import boringyuri.processor.util.AnnotationHandler
 import boringyuri.processor.type.CommonTypeName.STRING
-import boringyuri.processor.util.Logger
 import boringyuri.processor.type.TypeConverter
-import com.squareup.javapoet.*
+import boringyuri.processor.util.AnnotationHandler
+import boringyuri.processor.util.Logger
+import com.squareup.javapoet.ClassName
+import com.squareup.javapoet.CodeBlock
+import com.squareup.javapoet.FieldSpec
+import com.squareup.javapoet.MethodSpec
+import com.squareup.javapoet.ParameterSpec
+import com.squareup.javapoet.ParameterizedTypeName
 import javax.lang.model.element.Element
 import javax.lang.model.element.ExecutableElement
 import javax.lang.model.element.VariableElement
@@ -89,7 +94,7 @@ class TemplatePathSegment(
 }
 
 class VariableWritePathSegment(
-    val segment: VariableElement,
+    private val segment: VariableElement,
     private val methodParam: ParameterSpec,
     private val defaultValue: String?,
     private val encoded: Boolean,

--- a/processor/src/main/java/boringyuri/processor/util/AnnotationHandler.kt
+++ b/processor/src/main/java/boringyuri/processor/util/AnnotationHandler.kt
@@ -15,7 +15,10 @@
  */
 package boringyuri.processor.util
 
-import boringyuri.processor.type.CommonTypeName.*
+import boringyuri.processor.type.CommonTypeName.JB_NON_NULL
+import boringyuri.processor.type.CommonTypeName.JB_NULLABLE
+import boringyuri.processor.type.CommonTypeName.NON_NULL
+import boringyuri.processor.type.CommonTypeName.NULLABLE
 import com.squareup.javapoet.AnnotationSpec
 import com.squareup.javapoet.ClassName
 import com.squareup.javapoet.TypeName

--- a/processor/src/main/java/boringyuri/processor/util/ProcessorOptions.kt
+++ b/processor/src/main/java/boringyuri/processor/util/ProcessorOptions.kt
@@ -19,8 +19,6 @@ package boringyuri.processor.util
 import boringyuri.api.adapter.BoringTypeAdapter
 import boringyuri.processor.base.ProcessingSession
 import com.squareup.javapoet.ClassName
-import javax.lang.model.element.Element
-import kotlin.reflect.KClass
 
 internal object ProcessorOptions {
 
@@ -31,19 +29,6 @@ internal object ProcessorOptions {
      * Type: [String]
      */
     const val OPT_TYPE_ADAPTER_FACTORY = "boringyuri.type_adapter_factory"
-
-    @Deprecated(message = "Will be removed in 1.2.0", replaceWith = ReplaceWith(""))
-    fun warnOrderedSegmentsUsage(
-        session: ProcessingSession,
-        pathSegment: String,
-        originatingElement: Element? = null
-    ) {
-        session.logger.warn(originatingElement,
-            "DEPRECATED. {$pathSegment} is an ordered Uri path segment which will stop working " +
-                    "in BoringYURI 1.2.0. Make sure you migrated your Uri path to the named " +
-                    "path segments approach (eg. /uri/path/{segment}/with/{templates})."
-        )
-    }
 
     fun getTypeAdapterFactory(session: ProcessingSession): ClassName? {
         return try {

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -45,8 +45,8 @@ android {
     }
 
     compileOptions {
-        targetCompatibility 1.8
-        sourceCompatibility 1.8
+        targetCompatibility JavaVersion.VERSION_11
+        sourceCompatibility JavaVersion.VERSION_11
     }
 }
 
@@ -78,6 +78,6 @@ kapt {
 
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
     kotlinOptions {
-        jvmTarget = "1.8" // in order to compile Kotlin to java 8 bytecode
+        jvmTarget = "11" // in order to compile Kotlin to java 11 bytecode
     }
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -79,5 +79,6 @@ kapt {
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
     kotlinOptions {
         jvmTarget = "11" // in order to compile Kotlin to java 11 bytecode
+        freeCompilerArgs = ['-Xjvm-default=all']
     }
 }

--- a/sample/src/main/java/boringyuri/sample/MainActivity.kt
+++ b/sample/src/main/java/boringyuri/sample/MainActivity.kt
@@ -18,11 +18,11 @@ package boringyuri.sample
 
 import android.graphics.Rect
 import android.net.Uri
-import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.util.Log
 import android.widget.Button
 import android.widget.TextView
+import androidx.appcompat.app.AppCompatActivity
 import boringyuri.sample.data.Address
 import boringyuri.sample.uri.ContactUriBuilder
 import boringyuri.sample.uri.LocationUriBuilder

--- a/sample/src/main/java/boringyuri/sample/data/Album.kt
+++ b/sample/src/main/java/boringyuri/sample/data/Album.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2022 Anton Novikau
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package boringyuri.sample.data
+
+import boringyuri.api.Path
+import boringyuri.api.UriData
+
+@UriData("/album/{category}/{id}")
+interface Album : BaseAlbum {
+    @Path("id")
+    fun getId(): Long
+
+    override fun getAuthor(): String = "John Doe"
+}

--- a/sample/src/main/java/boringyuri/sample/data/BaseAlbum.kt
+++ b/sample/src/main/java/boringyuri/sample/data/BaseAlbum.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 Anton Novikau
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package boringyuri.sample.data
+
+import boringyuri.api.Param
+import boringyuri.api.Path
+import boringyuri.api.UriData
+
+@UriData("/album/{category}")
+interface BaseAlbum {
+    @Path("category")
+    fun getCategory(): String
+
+    @Param("author")
+    fun getAuthor(): String?
+}

--- a/sample/src/main/java/boringyuri/sample/data/BoringContactProvider.kt
+++ b/sample/src/main/java/boringyuri/sample/data/BoringContactProvider.kt
@@ -88,8 +88,11 @@ class BoringContactProvider : ContentProvider() {
         )
 
         val desiredDimens = uriData.desiredDimens
-        Log.i(TAG, "openContactPhoto: contactId = ${uriData.contactId}, group = ${uriData.group}," +
-                " desiredDimens = ${desiredDimens.width()}x${desiredDimens.height()}")
+        Log.i(
+            TAG,
+            "openContactPhoto: contactId = ${uriData.contactId}, group = ${uriData.group}," +
+                    " desiredDimens = ${desiredDimens.width()}x${desiredDimens.height()}"
+        )
 
         // pre-process 'photoFile' bitmap to have a desired width and height
         // based on 'uriData.desiredDimens'
@@ -106,9 +109,12 @@ class BoringContactProvider : ContentProvider() {
             context.getExternalFilesDir("vcard"),
             vcard.contactId.toString()
         )
-        Log.i(TAG, "openContactVCard: id = ${vcard.contactId}," +
-                " name = ${vcard.firstName} ${vcard.lastName}," +
-                " address = ${vcard.homeAddress}")
+        Log.i(
+            TAG,
+            "openContactVCard: id = ${vcard.contactId}," +
+                    " name = ${vcard.firstName} ${vcard.lastName}," +
+                    " address = ${vcard.homeAddress}"
+        )
 
         return ParcelFileDescriptor.open(vcardFile, ParcelFileDescriptor.MODE_READ_ONLY)
     }

--- a/sample/src/main/java/boringyuri/sample/data/MediaAlbum.kt
+++ b/sample/src/main/java/boringyuri/sample/data/MediaAlbum.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2022 Anton Novikau
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package boringyuri.sample.data
+
+import boringyuri.api.Param
+import boringyuri.api.UriData
+
+@UriData
+interface MediaAlbum {
+    @Param("mediaType")
+    fun getMediaType(): String
+
+    @Param
+    fun getFileSize(): Long
+}

--- a/sample/src/main/java/boringyuri/sample/data/PhotoAlbum.kt
+++ b/sample/src/main/java/boringyuri/sample/data/PhotoAlbum.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2022 Anton Novikau
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package boringyuri.sample.data
+
+import android.net.Uri
+import boringyuri.api.Param
+import boringyuri.api.UriData
+
+@UriData("/album/{category}/{id}")
+interface PhotoAlbum : Album, MediaAlbum {
+    @Param("thumbnail")
+    fun getThumbnailUri(): Uri
+
+    @Param("mimeType")
+    override fun getMediaType(): String
+}

--- a/sample/src/main/java/boringyuri/sample/data/VideoAlbum.kt
+++ b/sample/src/main/java/boringyuri/sample/data/VideoAlbum.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2022 Anton Novikau
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package boringyuri.sample.data
+
+import boringyuri.api.Param
+import boringyuri.api.UriData
+
+@UriData("/album/{category}/{id}")
+interface VideoAlbum : Album, MediaAlbum {
+    @Param
+    fun getTotalDuration(): Long
+}

--- a/sample/src/main/java/boringyuri/sample/test/TestArrayUriBuilder.java
+++ b/sample/src/main/java/boringyuri/sample/test/TestArrayUriBuilder.java
@@ -23,7 +23,6 @@ import androidx.annotation.Nullable;
 
 import boringyuri.api.DefaultValue;
 import boringyuri.api.Param;
-import boringyuri.api.Path;
 import boringyuri.api.UriBuilder;
 import boringyuri.api.UriFactory;
 import boringyuri.api.WithUriData;

--- a/sample/src/main/java/boringyuri/sample/uri/BackgroundProviderUriBuilder.kt
+++ b/sample/src/main/java/boringyuri/sample/uri/BackgroundProviderUriBuilder.kt
@@ -19,7 +19,11 @@ package boringyuri.sample.uri
 import android.content.ContentResolver
 import android.net.Uri
 import androidx.annotation.ColorInt
-import boringyuri.api.*
+import boringyuri.api.Param
+import boringyuri.api.Path
+import boringyuri.api.UriBuilder
+import boringyuri.api.UriFactory
+import boringyuri.api.WithUriData
 import boringyuri.api.matcher.MatcherCode
 import boringyuri.api.matcher.WithUriMatcher
 import boringyuri.sample.BuildConfig
@@ -32,7 +36,6 @@ interface BackgroundProviderUriBuilder {
         const val CODE_ORIGINAL = 101
         const val CODE_CROPPED = 102
         const val CODE_DEBUG = 103
-        const val CODE_ORDERED = 104
     }
 
     @UriBuilder("/bg/color/{color}")
@@ -54,7 +57,4 @@ interface BackgroundProviderUriBuilder {
     // so it can't be accepted as an annotation parameter.
     @MatcherCode(Contract.CODE_DEBUG, enabled = BuildConfig.DEBUG_ONLY)
     fun buildDebugBackgroundUri(): Uri
-
-    @UriBuilder("/bg/ordered")
-    fun buildOrderedUri(@Path first: String, @Path second: Int): Uri
 }

--- a/sample/src/main/java/boringyuri/sample/uri/ContactUriBuilder.java
+++ b/sample/src/main/java/boringyuri/sample/uri/ContactUriBuilder.java
@@ -23,14 +23,14 @@ import android.net.Uri;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import boringyuri.api.matcher.MatchesTo;
 import boringyuri.api.Param;
 import boringyuri.api.Path;
 import boringyuri.api.UriBuilder;
 import boringyuri.api.UriFactory;
 import boringyuri.api.WithUriData;
-import boringyuri.api.matcher.WithUriMatcher;
 import boringyuri.api.adapter.TypeAdapter;
+import boringyuri.api.matcher.MatchesTo;
+import boringyuri.api.matcher.WithUriMatcher;
 import boringyuri.sample.BuildConfig;
 import boringyuri.sample.data.Address;
 import boringyuri.sample.data.adapter.RectTypeAdapter;

--- a/sample/src/main/java/boringyuri/sample/uri/LocationUriBuilder.kt
+++ b/sample/src/main/java/boringyuri/sample/uri/LocationUriBuilder.kt
@@ -17,7 +17,11 @@
 package boringyuri.sample.uri
 
 import android.net.Uri
-import boringyuri.api.*
+import boringyuri.api.DefaultValue
+import boringyuri.api.Param
+import boringyuri.api.UriBuilder
+import boringyuri.api.UriFactory
+import boringyuri.api.WithUriData
 import boringyuri.api.adapter.TypeAdapter
 import boringyuri.api.constant.BooleanParam
 import boringyuri.api.constant.DoubleParam

--- a/sample/src/main/java/boringyuri/sample/uri/UserProviderUriBuilder.java
+++ b/sample/src/main/java/boringyuri/sample/uri/UserProviderUriBuilder.java
@@ -28,7 +28,7 @@ import boringyuri.api.adapter.TypeAdapter;
 import boringyuri.sample.data.User;
 import boringyuri.sample.data.adapter.AdminTypeAdapter;
 
-@UriFactory(scheme = "https", authority="example.com")
+@UriFactory(scheme = "https", authority = "example.com")
 public interface UserProviderUriBuilder {
 
     @NonNull


### PR DESCRIPTION
* Add support of inheritance in independent `Uri` data classes ([Issue #20](https://github.com/anton-novikau/boringYURI/issues/20)).
* Remove support of ordered path segments in favor of named path segments ([Issue #22](https://github.com/anton-novikau/boringYURI/issues/22)).
* Add `@Override` annotations to the generated getter methods in independent `Uri` data classes.
* Upgrade the dependencies.