### PR TITLE
Release Boring YURI v1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
+## Boring YURI 1.2.1 (2022-04-18)
+* Add multi-round incremental processing support for Dagger module annotation processor ([Bug #26](https://github.com/anton-novikau/boringYURI/issues/26)).
+* Add multi-round incremental processing support for `TypeAdapterFactory` annotation processor.
+* Upgrade dependencies.
+
 ## Boring YURI 1.2.0 (2022-01-06)
 * Add support of inheritance in independent `Uri` data classes ([Issue #20](https://github.com/anton-novikau/boringYURI/issues/20)).
 * Remove support of ordered path segments in favor of named path segments ([Issue #22](https://github.com/anton-novikau/boringYURI/issues/22)).
 * Add `@Override` annotations to the generated getter methods in independent `Uri` data classes.
-* Upgrade the dependencies.
+* Upgrade dependencies.
 
 ## Boring YURI 1.1.4 (2021-10-24)
 
@@ -15,7 +20,7 @@
   ones ([Issue #15](https://github.com/anton-novikau/boringYURI/issues/15)).
 * Add ability to disable a `Uri` in `UriMatcher` for a specific build type of a product flavor.
 * Add ability to provide a custom name to a `Uri` data class associated with the builder method.
-* Upgrade the dependencies.
+* Upgrade dependencies.
 
 ## Boring YURI 1.1.2 (2020-06-02)
 

--- a/README.md
+++ b/README.md
@@ -1057,8 +1057,8 @@ With Java only:
 
 ```groovy
 dependencies {
-  implementation "com.github.anton-novikau:boringyuri-api:1.2.0"
-  annotationProcessor "com.github.anton-novikau:boringyuri-processor:1.2.0"
+  implementation "com.github.anton-novikau:boringyuri-api:1.2.1"
+  annotationProcessor "com.github.anton-novikau:boringyuri-processor:1.2.1"
 }
 ```
 
@@ -1068,8 +1068,8 @@ With Kotlin:
 apply plugin: 'kotlin-kapt'
 
 dependencies {
-  implementation "com.github.anton-novikau:boringyuri-api:1.2.0"
-  kapt "com.github.anton-novikau:boringyuri-processor:1.2.0"
+  implementation "com.github.anton-novikau:boringyuri-api:1.2.1"
+  kapt "com.github.anton-novikau:boringyuri-processor:1.2.1"
 }
 ```
 Snapshots of the development version are available in [Sonatype's snapshots repository][4].

--- a/build.gradle
+++ b/build.gradle
@@ -16,37 +16,37 @@
 
 buildscript {
     // android
-    ext.gradlePluginVersion = '7.0.4'
-    ext.buildToolsVersion = '31.0.0'
-    ext.compile_sdk_version = 31
+    ext.gradlePluginVersion = '7.1.3'
+    ext.buildToolsVersion = '32.0.0'
+    ext.compile_sdk_version = 32
     ext.min_sdk_version = 17
-    ext.target_sdk_version = 31
+    ext.target_sdk_version = 32
 
     // androidx
-    ext.constraintLayoutVersion = '2.1.2'
-    ext.appCompatVersion = '1.4.0'
-    ext.annotationVersion = '1.1.0'
-    ext.lifecycleVersion = '2.4.0'
+    ext.constraintLayoutVersion = '2.1.3'
+    ext.appCompatVersion = '1.4.1'
+    ext.annotationVersion = '1.3.0'
+    ext.lifecycleVersion = '2.4.1'
 
     // kotlin
-    ext.kotlinVersion = '1.6.10'
-    ext.dokkaVersion = '1.5.31'
+    ext.kotlinVersion = '1.6.20'
+    ext.dokkaVersion = '1.6.20'
 
     // dagger
-    ext.daggerVersion = '2.39.1'
+    ext.daggerVersion = '2.41'
 
     // annotation processor
-    ext.autoServiceVersion = '1.0-rc7'
-    ext.autoCommonVersion = '0.11'
+    ext.autoServiceVersion = '1.0.1'
+    ext.autoCommonVersion = '1.2.1'
     ext.incapVersion = '0.3'
     ext.javaPoetVersion = '1.13.0'
-    ext.commonsTextVersion = '1.8'
+    ext.commonsTextVersion = '1.9'
 
     // unit tests
     ext.junitVersion = '4.13.2'
 
     // publishing
-    ext.publishPluginVersion = '0.18.0'
+    ext.publishPluginVersion = '0.19.0'
 
     repositories {
         google()

--- a/dagger/README.md
+++ b/dagger/README.md
@@ -58,7 +58,7 @@ With Java only:
 ```groovy
 dependencies {
          ...
-  annotationProcessor "com.github.anton-novikau:boringyuri-dagger:1.2.0"
+  annotationProcessor "com.github.anton-novikau:boringyuri-dagger:1.2.1"
 }
 ```
 
@@ -67,7 +67,7 @@ With Kotlin:
 ```groovy
 dependencies {
         ...
-  kapt "com.github.anton-novikau:boringyuri-dagger:1.2.0"
+  kapt "com.github.anton-novikau:boringyuri-dagger:1.2.1"
 }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Publishing
 USER = novikau
 GROUP = com.github.anton-novikau
-VERSION_NAME = 1.2.0
+VERSION_NAME = 1.2.1
 
 POM_DESCRIPTION = An annotation processor library for Uri building and parsing routines.
 POM_LICENCE_NAME = The Apache Software License, Version 2.0

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-all.zip


### PR DESCRIPTION
* Add multi-round incremental processing support for Dagger module annotation processor ([Bug #26](https://github.com/anton-novikau/boringYURI/issues/26)).
* Add multi-round incremental processing support for `TypeAdapterFactory` annotation processor.
* Upgrade dependencies.