### PR TITLE
Add GitHub action for publishing a SNAPSHOT build

### DIFF
--- a/.github/workflows/deploy_snapshot.yml
+++ b/.github/workflows/deploy_snapshot.yml
@@ -1,0 +1,43 @@
+name: Build & deploy snapshot
+on:
+  pull_request:
+    branches:
+      - develop
+    types: [closed]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up JDK environment
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: 11
+
+      - name: Setup Gradle cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build snapshot
+        run: ./gradlew -Psnapshot clean build
+
+      - name: Decode the secret key and place the file
+        run: |
+          echo "${{secrets.SIGNING_SECRET_KEY_RING_FILE}}" > ~/.gradle/secring.gpg.b64
+          base64 -d ~/.gradle/secring.gpg.b64 > ~/.gradle/secring.gpg
+
+      - name: Deploy snapshot
+        run: ./gradlew uploadArchives --no-daemon --no-parallel -Psnapshot -PmavenCentralUsername=${{secrets.SONATYPE_NEXUS_USERNAME}} -PmavenCentralPassword=${{secrets.SONATYPE_NEXUS_PASSWORD}} -Psigning.keyId=${{secrets.SIGNING_KEY_ID}} -Psigning.password=${{secrets.SIGNING_PASSWORD}} -Psigning.secretKeyRingFile=$(echo ~/.gradle/secring.gpg)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,6 +29,15 @@ buildscript {
 }
 
 allprojects {
+    val isSnapshot = hasProperty("snapshot")
+    if (isSnapshot) {
+        val version = findProperty("VERSION_NAME")?.toString()
+        if (version != null) {
+            // add '-SNAPSHOT' suffix to an existing version when
+            // it was requested to build a snapshot.
+            setProperty("VERSION_NAME", "$version-SNAPSHOT")
+        }
+    }
     repositories {
         google()
         mavenCentral()

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,10 @@
 # Publishing
 USER = novikau
 GROUP = com.github.anton-novikau
-VERSION_NAME = 1.2.1
+VERSION_NAME = 1.2.2
 
 POM_DESCRIPTION = An annotation processor library for Uri building and parsing routines.
+POM_INCEPTION_YEAR=2020
 POM_LICENCE_NAME = The Apache Software License, Version 2.0
 POM_LICENSE_URL = http://www.apache.org/licenses/LICENSE-2.0.txt
 POM_LICENSE_DIST = repo


### PR DESCRIPTION
A SNAPSHOT build is published automatically to `MavenCentral` on every merge from a feature branch to `develop`. The defined `VERSION_NAME` is altered in order to have a required version suffix when a build was requested from a snapshot publishing CI action.