### PR TITLE
[1.2.2] Add publishing configuration explicitly

### DIFF
--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -42,7 +42,7 @@ jobs:
         run: ./gradlew clean build
 
       - name: Deploy release
-        run: ./gradlew publish --no-daemon --no-parallel
+        run: ./gradlew publish
 
       - name: Close & release repository
         run: ./gradlew closeAndReleaseRepository

--- a/.github/workflows/deploy_snapshot.yml
+++ b/.github/workflows/deploy_snapshot.yml
@@ -42,4 +42,4 @@ jobs:
         run: ./gradlew -Psnapshot clean build
 
       - name: Deploy snapshot
-        run: ./gradlew publish --no-daemon --no-parallel -Psnapshot
+        run: ./gradlew publish -Psnapshot

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,6 +16,9 @@ POM_SCM_URL = https://github.com/anton-novikau/boringYURI
 POM_SCM_CONNECTION = scm:git:git://github.com/anton-novikau/boringYURI.git
 POM_SCM_DEV_CONNECTION = scm:git:ssh://git@github.com/anton-novikau/boringYURI.git
 
+SONATYPE_HOST=DEFAULT
+RELEASE_SIGNING_ENABLED=true
+
 # Project-wide Gradle settings.
 org.gradle.jvmargs=-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 org.gradle.configureondemand=false


### PR DESCRIPTION
Automatic release signing and a sonatype host became required in the publishing plugin `0.22.0`