### PR TITLE
- fix TypeAdapterFactoryGeneratorStep.kt

### DIFF
--- a/processor-steps/src/main/java/boringyuri/processor/common/steps/TypeAdapterFactoryGeneratorStep.kt
+++ b/processor-steps/src/main/java/boringyuri/processor/common/steps/TypeAdapterFactoryGeneratorStep.kt
@@ -80,7 +80,7 @@ class TypeAdapterFactoryGeneratorStep(session: ProcessingSession) : BoringProces
         }
 
         val roundClassNames = roundClasses.map {
-            ClassName.bestGuess(it.toString())
+            ClassName.bestGuess(it.typeName.toString())
         }
         if (sourceClasses.addAll(roundClassNames)) {
             roundClassNames.forEach {

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -113,7 +113,7 @@ dependencies {
 
 if (useKsp) {
     ksp {
-        arg("boringyuri.type_adapter_factory", "boringyuri.sample.data.adapter.TypeAdapterFactory")
+        arg("boringyuri.type_adapter_factory", "boringyuri.sample.data.adapter.factory.TypeAdapterFactory")
     }
 } else {
     kapt {
@@ -124,7 +124,7 @@ if (useKsp) {
         arguments {
             arg(
                 "boringyuri.type_adapter_factory",
-                "boringyuri.sample.data.adapter.TypeAdapterFactory"
+                "boringyuri.sample.data.adapter.factory.TypeAdapterFactory"
             )
         }
     }


### PR DESCRIPTION
The problem is:
`KspType.toString() `returns `SomeProjectClass`
`JavacType.toString()` returns  `com.myapplication.SomeProjectClass`
It causes a bug that generated `TypeAdapterFactory` does not contain imports of classes from other packages when `ksp` is enabled