### PR TITLE
Integrate robolictric and add tests for generated classes

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,6 +20,7 @@ ksp = "2.2.20-2.0.3"
 mavenPublish = "0.34.0"
 room = "2.7.2"
 viewmodel = "2.9.4"
+robolectric = "4.16"
 
 [libraries]
 androidx-annotation = { module = "androidx.annotation:annotation", version.ref = "annotations" }
@@ -43,6 +44,8 @@ square-javaPoet = { module = "com.squareup:javapoet", version.ref = "javapoet" }
 
 junit = { module = "junit:junit", version.ref = "junit" }
 
+robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
+
 [bundles]
 dagger = [
     "dagger-core",
@@ -57,7 +60,7 @@ dagger-compiler = [
 [plugins]
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
-kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin"}
+kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
 kotlin-ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 kotlin-dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 android-library = { id = "com.android.library", version.ref = "agp" }

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -112,6 +112,7 @@ dependencies {
 
     // unit tests
     testImplementation(libs.junit)
+    testImplementation(libs.robolectric)
 }
 
 if (useKsp) {

--- a/sample/src/test/kotlin/boringyuri/sample/data/AlbumImplTest.kt
+++ b/sample/src/test/kotlin/boringyuri/sample/data/AlbumImplTest.kt
@@ -1,0 +1,36 @@
+package boringyuri.sample.data
+
+import android.net.Uri
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class AlbumImplTest {
+
+    private val uriString = "content://albums/album/myAlbum/123"
+    private val uri = Uri.parse(uriString)
+
+    val sut = AlbumImpl(uri)
+
+    @Test
+    fun testCategoryCorrect() {
+        Assert.assertEquals("myAlbum", sut.getCategory())
+    }
+
+    @Test
+    fun testIdCorrect() {
+        Assert.assertEquals(123L, sut.getId())
+    }
+
+    @Test
+    fun testAuthorCorrect() {
+        Assert.assertEquals("John Doe", sut.getAuthor())
+    }
+
+    @Test
+    fun testToStringCorrect() {
+        Assert.assertEquals(sut.toString(), uriString)
+    }
+}

--- a/sample/src/test/kotlin/boringyuri/sample/data/BaseAlbumImplTest.kt
+++ b/sample/src/test/kotlin/boringyuri/sample/data/BaseAlbumImplTest.kt
@@ -1,0 +1,32 @@
+package boringyuri.sample.data
+
+import android.net.Uri
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class BaseAlbumImplTest {
+    private val category = "myCategory"
+    private val author = "Favorite Author"
+    private val uriString = "content://albums/album/$category?author=$author"
+    private val uri = Uri.parse(uriString)
+
+    private val sut = BaseAlbumImpl(uri)
+
+    @Test
+    fun testCategoryCorrect() {
+        assertEquals(category, sut.getCategory())
+    }
+
+    @Test
+    fun testAuthorCorrect() {
+        assertEquals(author, sut.getAuthor())
+    }
+
+    @Test
+    fun testToStringCorrect() {
+        assertEquals(sut.toString(), uriString)
+    }
+}

--- a/sample/src/test/kotlin/boringyuri/sample/data/ContactDetailsDataImplTest.kt
+++ b/sample/src/test/kotlin/boringyuri/sample/data/ContactDetailsDataImplTest.kt
@@ -1,0 +1,56 @@
+package boringyuri.sample.data
+
+import android.net.Uri
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class ContactDetailsDataImplTest {
+
+    private val id = 123L
+    private val title = "FamilyGuy"
+    private val firstName = "Peter"
+    private val lastName = "Griffin"
+    private val city = "Quahog"
+    private val street = "Spooner str."
+    private val zipCode = "12345"
+    private val address = "$city;$street;$zipCode"
+
+    private val uriString =
+        "content://contacts/users/user/$id/$title?firstName=$firstName&lastName=$lastName&address=$address"
+    private val testUri = Uri.parse(uriString)
+
+    private val sut = ContactDetailsDataImpl(testUri)
+
+    @Test
+    fun testIdCorrect() {
+        Assert.assertEquals(id, sut.getId())
+    }
+
+    @Test
+    fun testTitleCorrect() {
+        Assert.assertEquals(title, sut.getTitle())
+    }
+
+    @Test
+    fun testFirstNameCorrect() {
+        Assert.assertEquals(firstName, sut.getFirstName())
+    }
+
+    @Test
+    fun testLastNameCorrect() {
+        Assert.assertEquals(lastName, sut.getLastName())
+    }
+
+    @Test
+    fun testHomeAddressCorrect() {
+        Assert.assertEquals(Address(city, street, zipCode), sut.getHomeAddress())
+    }
+
+    @Test
+    fun testToStringCorrect() {
+        Assert.assertEquals(uriString, sut.toString())
+    }
+}

--- a/sample/src/test/kotlin/boringyuri/sample/data/ContactPhotoUriDataImplTest.kt
+++ b/sample/src/test/kotlin/boringyuri/sample/data/ContactPhotoUriDataImplTest.kt
@@ -1,0 +1,41 @@
+package boringyuri.sample.data
+
+import android.graphics.Rect
+import android.net.Uri
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class ContactPhotoUriDataImplTest {
+    private val testGroup = "testGroup"
+    private val testId = 123L
+    private val testDimension = Rect(0, 0, 300, 300)
+
+    private val uriString =
+        "content://contacts/groups/$testGroup/person/$testId?desired_dimensions=${testDimension.flattenToString()}"
+    private val testUri = Uri.parse(uriString)
+
+    private val sut = ContactPhotoUriDataImpl(testUri)
+
+    @Test
+    fun testGroupCorrect() {
+        Assert.assertEquals(testGroup, sut.group)
+    }
+
+    @Test
+    fun testContactIdCorrect() {
+        Assert.assertEquals(testId, sut.contactId)
+    }
+
+    @Test
+    fun testDesiredDimensCorrect() {
+        Assert.assertEquals(testDimension, sut.desiredDimens)
+    }
+
+    @Test
+    fun testToStringCorrect() {
+        Assert.assertEquals(uriString, sut.toString())
+    }
+}

--- a/sample/src/test/kotlin/boringyuri/sample/data/CroppedBackgroundDataTest.kt
+++ b/sample/src/test/kotlin/boringyuri/sample/data/CroppedBackgroundDataTest.kt
@@ -1,0 +1,33 @@
+package boringyuri.sample.data
+
+import android.net.Uri
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class CroppedBackgroundDataTest {
+    private val testId = "bg123"
+    private val testOrientation = 2
+    private val testUriString =
+        "content://boringyuri.sample.backgrounds/bg/thumbnail/$testId?orientation=$testOrientation"
+    private val uri = Uri.parse(testUriString)
+
+    private val sut = CroppedBackgroundData(uri)
+
+    @Test
+    fun testBackgroundIdCorrect() {
+        Assert.assertEquals(testId, sut.backgroundId)
+    }
+
+    @Test
+    fun testOrientationCorrect() {
+        Assert.assertEquals(testOrientation, sut.orientation)
+    }
+
+    @Test
+    fun testToStringCorrect() {
+        Assert.assertEquals(testUriString, sut.toString())
+    }
+}

--- a/sample/src/test/kotlin/boringyuri/sample/data/MediaAlbumImplTest.kt
+++ b/sample/src/test/kotlin/boringyuri/sample/data/MediaAlbumImplTest.kt
@@ -1,0 +1,31 @@
+package boringyuri.sample.data
+
+import android.net.Uri
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class MediaAlbumImplTest {
+    private val testMediaType = "photo"
+    private val testFileSize = 2048L
+    private val testUriString = "content://any/uri?mediaType=$testMediaType&fileSize=$testFileSize"
+    private val testUri = Uri.parse(testUriString)
+    private val sut = MediaAlbumImpl(testUri)
+
+    @Test
+    fun getMediaType() {
+        Assert.assertEquals(testMediaType, sut.getMediaType())
+    }
+
+    @Test
+    fun getFileSize() {
+        Assert.assertEquals(testFileSize, sut.getFileSize())
+    }
+
+    @Test
+    fun testToString() {
+        Assert.assertEquals(testUriString, sut.toString())
+    }
+}

--- a/sample/src/test/kotlin/boringyuri/sample/data/PhotoAlbumImplTest.kt
+++ b/sample/src/test/kotlin/boringyuri/sample/data/PhotoAlbumImplTest.kt
@@ -1,0 +1,56 @@
+package boringyuri.sample.data
+
+import android.net.Uri
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class PhotoAlbumImplTest {
+    private val category = "vacation"
+    private val id = 123L
+    private val fileSize = 123456L
+    private val thumbnail = "http://random.domain.com/random"
+    private val mimeType = "image/jpeg"
+    private val uriString =
+        "content://albums/album/$category/$id?thumbnail=$thumbnail&mimeType=$mimeType&mediaType=unused&fileSize=$fileSize"
+    private val uri = Uri.parse(uriString)
+
+    private val sut = PhotoAlbumImpl(uri)
+
+    @Test
+    fun getCategory() {
+        Assert.assertEquals(category, sut.getCategory())
+    }
+
+    @Test
+    fun getId() {
+        Assert.assertEquals(id, sut.getId())
+    }
+
+    @Test
+    fun getMediaType() {
+        Assert.assertEquals(mimeType, sut.getMediaType())
+    }
+
+    @Test
+    fun getFileSize() {
+        Assert.assertEquals(fileSize, sut.getFileSize())
+    }
+
+    @Test
+    fun getThumbnailUri() {
+        Assert.assertEquals(thumbnail, sut.getThumbnailUri().toString())
+    }
+
+    @Test
+    fun testToString() {
+        Assert.assertEquals(uriString, sut.toString())
+    }
+
+    @Test
+    fun testAuthorCorrect() {
+        Assert.assertEquals("John Doe", sut.getAuthor())
+    }
+}

--- a/sample/src/test/kotlin/boringyuri/sample/data/VideoAlbumImplTest.kt
+++ b/sample/src/test/kotlin/boringyuri/sample/data/VideoAlbumImplTest.kt
@@ -1,0 +1,57 @@
+package boringyuri.sample.data
+
+import android.net.Uri
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class VideoAlbumImplTest {
+
+    private val category = "vacation"
+    private val id = 123L
+    private val duration = 1234567L
+    private val fileSize = 456789L
+    private val mimeType = "video/mp4"
+    private val uriString =
+        "content://albums/album/$category/$id?mediaType=$mimeType&totalDuration=$duration&fileSize=$fileSize"
+    private val uri = Uri.parse(uriString)
+
+    private val sut = VideoAlbumImpl(uri)
+
+    @Test
+    fun getTotalDuration() {
+        Assert.assertEquals(duration, sut.getTotalDuration())
+    }
+
+    @Test
+    fun getCategory() {
+        Assert.assertEquals(category, sut.getCategory())
+    }
+
+    @Test
+    fun getId() {
+        Assert.assertEquals(id, sut.getId())
+    }
+
+    @Test
+    fun getMediaType() {
+        Assert.assertEquals(mimeType, sut.getMediaType())
+    }
+
+    @Test
+    fun getFileSize() {
+        Assert.assertEquals(fileSize, sut.getFileSize())
+    }
+
+    @Test
+    fun testToString() {
+        Assert.assertEquals(uriString, sut.toString())
+    }
+
+    @Test
+    fun testAuthorCorrect() {
+        Assert.assertEquals("John Doe", sut.getAuthor())
+    }
+}

--- a/sample/src/test/kotlin/boringyuri/sample/data/adapter/factory/TypeAdapterFactoryTest.kt
+++ b/sample/src/test/kotlin/boringyuri/sample/data/adapter/factory/TypeAdapterFactoryTest.kt
@@ -1,0 +1,48 @@
+package boringyuri.sample.data.adapter.factory
+
+import org.junit.Assert
+import org.junit.Test
+
+class TypeAdapterFactoryTest {
+    @Test
+    fun testCreateAddressTypeAdapter() {
+        val addressTypeAdapter = TypeAdapterFactory.createAddressTypeAdapter()
+        val addressTypeAdapter2 = TypeAdapterFactory.createAddressTypeAdapter()
+        Assert.assertSame(addressTypeAdapter, addressTypeAdapter2)
+    }
+
+    @Test
+    fun testCreateAdminTypeAdapter() {
+        val adminTypeAdapter = TypeAdapterFactory.createAdminTypeAdapter()
+        val adminTypeAdapter2 = TypeAdapterFactory.createAdminTypeAdapter()
+        Assert.assertSame(adminTypeAdapter, adminTypeAdapter2)
+    }
+
+    @Test
+    fun testCreateCoordinatesTypeAdapter() {
+        val coordinatesTypeAdapter = TypeAdapterFactory.createCoordinatesTypeAdapter()
+        val coordinatesTypeAdapter2 = TypeAdapterFactory.createCoordinatesTypeAdapter()
+        Assert.assertSame(coordinatesTypeAdapter, coordinatesTypeAdapter2)
+    }
+
+    @Test
+    fun testCreateDoubleArrayTypeAdapter() {
+        val doubleArrayTypeAdapter = TypeAdapterFactory.createDoubleArrayTypeAdapter()
+        val doubleArrayTypeAdapter2 = TypeAdapterFactory.createDoubleArrayTypeAdapter()
+        Assert.assertSame(doubleArrayTypeAdapter, doubleArrayTypeAdapter2)
+    }
+
+    @Test
+    fun testCreateRectTypeAdapter() {
+        val rectTypeAdapter = TypeAdapterFactory.createRectTypeAdapter()
+        val rectTypeAdapter2 = TypeAdapterFactory.createRectTypeAdapter()
+        Assert.assertSame(rectTypeAdapter, rectTypeAdapter2)
+    }
+
+    @Test
+    fun testCreateUserTypeAdapter() {
+        val userTypeAdapter = TypeAdapterFactory.createUserTypeAdapter()
+        val userTypeAdapter2 = TypeAdapterFactory.createUserTypeAdapter()
+        Assert.assertSame(userTypeAdapter, userTypeAdapter2)
+    }
+}

--- a/sample/src/test/kotlin/boringyuri/sample/uri/BackgroundProviderUriBuilderImplTest.kt
+++ b/sample/src/test/kotlin/boringyuri/sample/uri/BackgroundProviderUriBuilderImplTest.kt
@@ -1,0 +1,47 @@
+package boringyuri.sample.uri
+
+import android.net.Uri
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class BackgroundProviderUriBuilderImplTest {
+
+    private val sut = BackgroundProviderUriBuilderImpl()
+    val baseUriString = "content://boringyuri.sample.backgrounds/bg"
+
+    @Test
+    fun buildColorBackgroundUri() {
+        val expected = Uri.parse("$baseUriString/color/255")
+        val actual = sut.buildColorBackgroundUri(255)
+
+        Assert.assertEquals(expected, actual)
+    }
+
+    @Test
+    fun buildGalleryBackgroundUri() {
+        val expected = Uri.parse("$baseUriString/original/123")
+        val actual = sut.buildGalleryBackgroundUri(123)
+
+        Assert.assertEquals(expected, actual)
+    }
+
+    @Test
+    fun buildCroppedBackgroundUri() {
+        val backgroundId = "bgid1"
+        val expected = Uri.parse("$baseUriString/thumbnail/$backgroundId?orientation=1")
+        val actual = sut.buildCroppedBackgroundUri(backgroundId, 1)
+
+        Assert.assertEquals(expected, actual)
+    }
+
+    @Test
+    fun buildDebugBackgroundUri() {
+        val expected = Uri.parse("$baseUriString/debug")
+        val actual = sut.buildDebugBackgroundUri()
+
+        Assert.assertEquals(expected, actual)
+    }
+}

--- a/sample/src/test/kotlin/boringyuri/sample/uri/LocationUriBuilderImplTest.kt
+++ b/sample/src/test/kotlin/boringyuri/sample/uri/LocationUriBuilderImplTest.kt
@@ -1,0 +1,80 @@
+package boringyuri.sample.uri
+
+import android.net.Uri
+import boringyuri.sample.data.Address
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class LocationUriBuilderImplTest {
+
+    private val baseUri = "https://maps.example.com/maps/api"
+
+    private val sut = LocationUriBuilderImpl()
+
+    @Test
+    fun buildStaticMapUri() {
+        val lat = 0.01
+        val lng = 0.02
+        val expected = Uri.parse(
+            "$baseUri/staticmap?lat=$lat&lng=$lng&sensor=true&zoom=2.5"
+        )
+        val actual = sut.buildStaticMapUri(lat, lng)
+
+        Assert.assertEquals(expected, actual)
+    }
+
+    @Test
+    fun buildAddressUri() {
+        val address = Address("Minsk", "Nemiga")
+        val expected = Uri.parse("$baseUri/geocode?address=Minsk%3BNemiga%3Bnull&sensor=true")
+        val actual = sut.buildAddressUri(address)
+        Assert.assertEquals(expected, actual)
+    }
+
+    @Test
+    fun buildGeocodeUri() {
+        val lat = 1L
+        val lng = 2L
+        val expected = Uri.parse(
+            "$baseUri/geocode?latlng=$lat%2C$lng&address=Minsk%3BNemiga%3Bnull&sensor=true"
+        )
+        val address = Address("Minsk", "Nemiga")
+        val actual = sut.buildGeocodeUri(lat to lng, address)
+
+        Assert.assertEquals(expected, actual)
+    }
+
+    @Test
+    fun buildShowPinsUri() {
+        val latLng = arrayOf(1L to 2L, 3L to 4L)
+        val latLngParams = latLng.joinToString(separator = "&") { (lat, lng) ->
+            "latlng=$lat%2C$lng"
+        }
+
+        val expected = Uri.parse("$baseUri/pins?$latLngParams&zoom=4.5")
+        val actual = sut.buildShowPinsUri(latLng)
+
+        Assert.assertEquals(expected, actual)
+    }
+
+    @Test
+    fun buildShowPinsByCoordinatesUri() {
+        val coordinates = arrayOf(
+            doubleArrayOf(0.1, 0.2),
+            doubleArrayOf(0.3, 0.4),
+            doubleArrayOf(0.5, 0.6),
+        )
+
+        val pinParams = coordinates.joinToString(separator = "&") { "pin=${it[0]}%3B${it[1]}" }
+
+        val expected = Uri.parse(
+            "$baseUri/pins?$pinParams&zoom=4.5"
+        )
+        val actual = sut.buildShowPinsByCoordinatesUri(coordinates)
+
+        Assert.assertEquals(expected, actual)
+    }
+}

--- a/sample/src/test/kotlin/boringyuri/sample/uri/matcher/BackgroundUriMatcherTest.kt
+++ b/sample/src/test/kotlin/boringyuri/sample/uri/matcher/BackgroundUriMatcherTest.kt
@@ -30,10 +30,12 @@ class BackgroundUriMatcherTest {
             BackgroundProviderUriBuilder.Contract.CODE_CROPPED,
             sut.match(Uri.parse("content://boringyuri.sample.backgrounds/bg/thumbnail/abc"))
         )
-        Assert.assertEquals(
-            BackgroundProviderUriBuilder.Contract.CODE_DEBUG,
-            sut.match(Uri.parse("content://boringyuri.sample.backgrounds/bg/debug"))
-        )
+        if (boringyuri.sample.BuildConfig.DEBUG_ONLY) {
+            Assert.assertEquals(
+                BackgroundProviderUriBuilder.Contract.CODE_DEBUG,
+                sut.match(Uri.parse("content://boringyuri.sample.backgrounds/bg/debug"))
+            )
+        }
         Assert.assertEquals(
             UriMatcher.NO_MATCH,
             sut.match(Uri.parse("content://boringyuri.sample.backgrounds/bg/random"))

--- a/sample/src/test/kotlin/boringyuri/sample/uri/matcher/BackgroundUriMatcherTest.kt
+++ b/sample/src/test/kotlin/boringyuri/sample/uri/matcher/BackgroundUriMatcherTest.kt
@@ -1,0 +1,42 @@
+package boringyuri.sample.uri.matcher
+
+import android.content.UriMatcher
+import android.net.Uri
+import boringyuri.sample.uri.BackgroundProviderUriBuilder
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class BackgroundUriMatcherTest {
+    @Test(expected = UnsupportedOperationException::class)
+    fun addURI() {
+        BackgroundUriMatcher().addURI("", "", 1)
+    }
+
+    @Test
+    fun match() {
+        val sut = BackgroundUriMatcher()
+        Assert.assertEquals(
+            BackgroundProviderUriBuilder.Contract.CODE_COLOR,
+            sut.match(Uri.parse("content://boringyuri.sample.backgrounds/bg/color/1"))
+        )
+        Assert.assertEquals(
+            BackgroundProviderUriBuilder.Contract.CODE_ORIGINAL,
+            sut.match(Uri.parse("content://boringyuri.sample.backgrounds/bg/original/1"))
+        )
+        Assert.assertEquals(
+            BackgroundProviderUriBuilder.Contract.CODE_CROPPED,
+            sut.match(Uri.parse("content://boringyuri.sample.backgrounds/bg/thumbnail/abc"))
+        )
+        Assert.assertEquals(
+            BackgroundProviderUriBuilder.Contract.CODE_DEBUG,
+            sut.match(Uri.parse("content://boringyuri.sample.backgrounds/bg/debug"))
+        )
+        Assert.assertEquals(
+            UriMatcher.NO_MATCH,
+            sut.match(Uri.parse("content://boringyuri.sample.backgrounds/bg/random"))
+        )
+    }
+}


### PR DESCRIPTION
Here I added some tests for generated classes to avoid regressions in future. Currently it does not cover all cases. In general, it is required to create sample code for all possible variations with BoringYURI annotations and cover them with tests, but I think it is a good start for now. @anton-novikau please, take a look.

To run the tests you need to execute `gradlew :sample:testDebugUnitTest`. After switching between KAPT and KSP it is required to clean project before running tests: `gradlew :sample:clean :sample:testDebugUnitTest`